### PR TITLE
Add support for appending decimal values

### DIFF
--- a/duckdb-test.lisp
+++ b/duckdb-test.lisp
@@ -368,6 +368,17 @@
   (test-append "float" '(3.14s0))
   (test-append "double" '(2.71d0)))
 
+(test append-decimal
+  (test-append "DECIMAL(38,38)"
+      (list (/ 33333333333333333333333333333333333333
+               100000000000000000000000000000000000000)))
+  (test-append "DECIMAL(7,6)" '(3141592/1000000))
+  (test-append "DECIMAL(10,5)" '(123))
+  (test-append "DECIMAL(10,5)" '(123.5s0)
+               :convert #'rationalize)
+  (test-append "DECIMAL(10,5)" '(123.5d0)
+               :convert #'rationalize))
+
 (test append-date
   (test-append "date" (list (local-time:today)) :test local-time:timestamp=))
 

--- a/duckdb.lisp
+++ b/duckdb.lisp
@@ -636,6 +636,14 @@ intentionally."
                  (duckdb-api:duckdb-append-blob handle ptr length))))
             (:duckdb-float (duckdb-api:duckdb-append-float handle value))
             (:duckdb-double (duckdb-api:duckdb-append-double handle value))
+            (:duckdb-decimal
+             (etypecase value
+               (ratio (duckdb-api:duckdb-append-varchar
+                       handle (rational-to-string value 38)))
+               (single-float (duckdb-api:duckdb-append-float handle value))
+               (double-float (duckdb-api:duckdb-append-double handle value))
+               (integer (duckdb-api:duckdb-append-varchar
+                         handle (format nil "~d" value)))))
             ;; 8-bit integers
             (:duckdb-tinyint (duckdb-api:duckdb-append-int8 handle value))
             (:duckdb-utinyint (duckdb-api:duckdb-append-uint8 handle value))


### PR DESCRIPTION
This doesn't seem to work as expected with the current DuckDB release 0.5.1