### PR TITLE
Add support for Lisp worker threads and use them on ECL by default

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,10 +138,10 @@ Please note that the API is experimental and subject to changes.
 
 *** Querying Lisp vectors and lists as table columns
 
-Currently only SBCL & CCL are supported with the following types (the
-values are currently copied into DuckDB data chunks internally). Using
-a combination of vectors and list for different columns is possible,
-but each column should have the same length. Tables using Lisp data
+Currently only the following types are supported (the values are
+currently copied into DuckDB data chunks internally). Using a
+combination of vectors and list for different columns is possible, but
+each column should have the same length. Tables using Lisp data
 structures are not bound to a single connection and work across
 different ones.
 

--- a/duckdb-test.lisp
+++ b/duckdb-test.lisp
@@ -22,10 +22,16 @@
           (is (equalp (get-thread-counts) (vector 1 0)))))
       (ddb:with-threads 2
         (ddb:with-transient-connection
-          (is (equalp (get-thread-counts) (vector 1 1)))))
+          (is (equalp (get-thread-counts)
+                      (if bt:*supports-threads-p*
+                          (vector 1 1)
+                          (vector 1 0))))))
       (ddb:with-threads t
         (ddb:with-transient-connection
-          (is (equalp (get-thread-counts) (vector 1 (1- cpu-count)))))))))
+          (is (equalp (get-thread-counts)
+                      (if bt:*supports-threads-p*
+                          (vector 1 (1- cpu-count))
+                          (vector 1 0)))))))))
 
 (defmacro test-query (query parameters result-syms &body body)
   (alexandria:with-gensyms (db conn results)

--- a/duckdb-test.lisp
+++ b/duckdb-test.lisp
@@ -366,7 +366,6 @@
             :for tuber :in tubers
             :do (ddb:append-row appender (list tuber))))))
 
-#-ecl
 (test static-table-booleans
   (ddb:with-transient-connection
     (ddb:with-static-table
@@ -381,7 +380,6 @@
         (is (equalp (ddb:get-result r1 'count) #(3 3)))
         (is (equalp (ddb:get-result r2 'count) #(1 2 3)))))))
 
-#-ecl
 (test static-table-integers
   (labels ((get-table-name (type)
              (format nil "~a" type)))
@@ -418,7 +416,6 @@
         (dolist (table-name table-names)
           (ddb:unbind-static-table table-name))))))
 
-#-ecl
 (test static-table-floats
   (let* ((floats nil)
          (doubles nil)
@@ -441,7 +438,6 @@
         (is (eql (cdr sums)
                  (ddb:get-result (ddb:query double-query nil) 'sum 0)))))))
 
-#-ecl
 (test static-table-scopes
   (ddb:with-transient-connection
     (labels ((get-scope (table-name)

--- a/duckdb-test.lisp
+++ b/duckdb-test.lisp
@@ -11,7 +11,7 @@
   (let ((query (str:concat "SELECT current_setting('threads') AS n"
                            " UNION ALL "
                            "SELECT current_setting('external_threads') AS n"))
-        (cpu-count (cpus:get-number-of-processors)))
+        (cpu-count (serapeum:count-cpus)))
     (labels ((get-thread-counts ()
                (ddb:get-result (ddb:query query nil) 'n)))
       (ddb:with-threads nil

--- a/duckdb.asd
+++ b/duckdb.asd
@@ -5,7 +5,8 @@
   :author "Ákos Kiss <ak@coram.pub>"
   :license  "MIT License"
   :serial t
-  :depends-on (#:cffi
+  :depends-on (#:bordeaux-threads
+               #:cffi
                #:cffi-libffi
                #:cl-ascii-table
                #:cl-spark

--- a/duckdb.asd
+++ b/duckdb.asd
@@ -9,7 +9,6 @@
                #:cffi
                #:cffi-libffi
                #:cl-ascii-table
-               #:cl-cpus
                #:cl-spark
                #:local-time
                #:local-time-duration

--- a/duckdb.asd
+++ b/duckdb.asd
@@ -9,6 +9,7 @@
                #:cffi
                #:cffi-libffi
                #:cl-ascii-table
+               #:cl-cpus
                #:cl-spark
                #:local-time
                #:local-time-duration

--- a/duckdb.lisp
+++ b/duckdb.lisp
@@ -80,7 +80,7 @@ for THREADS."
                  (when threads
                    (1- (etypecase threads
                          ((integer 1) threads)
-                         (boolean (cpus:get-number-of-processors)))))))
+                         (boolean (serapeum:count-cpus)))))))
 
 (defun close-database (database)
   "Does resource cleanup for DATABASE, also see OPEN-DATABASE."

--- a/duckdb.lisp
+++ b/duckdb.lisp
@@ -44,12 +44,20 @@
               (error 'duckdb-error
                      :error-message (duckdb-api:get-message p-error-message))))))))
 
-(defun open-database (&key (path ":memory:") (threads #-ECL nil #+ECL 12))
+(defun open-database (&key (path ":memory:") (threads #-ECL nil #+ECL t))
   "Opens and returns database for PATH with \":memory:\" as default.
+If THREADS is a positive integer, a thread pool with a matching number
+of threads is used to replace the internal thread management of
+DuckDB (when set to T, the number of CPU cores is used instead). This
+is only enabled on ECL with thread support by default.
+
 See CLOSE-DATABASE for cleanup."
   (make-instance 'database :path path
-                           :threads (when bt:*supports-threads-p*
-                                      threads)))
+                           :threads
+                           (when (and threads bt:*supports-threads-p*)
+                             (etypecase threads
+                               ((integer 1) threads)
+                               (boolean (cpus:get-number-of-processors))))))
 
 (defun close-database (database)
   "Does resource cleanup for DATABASE, also see OPEN-DATABASE."

--- a/package.lisp
+++ b/package.lisp
@@ -109,6 +109,8 @@
   (:nicknames #:ddb)
   (:use #:cl #:cffi)
   (:export #:*connection*
+           #:*threads*
+           #:with-threads
            #:open-database
            #:close-database
            #:connect

--- a/package.lisp
+++ b/package.lisp
@@ -100,7 +100,10 @@
            #:clear-table-reference
            #:clear-table-references
            #:register-static-table-function
-           #:add-static-table-replacement-scan))
+           #:add-static-table-replacement-scan
+           #:with-config
+           #:start-worker-pool
+           #:stop-worker-pool))
 
 (defpackage #:duckdb
   (:nicknames #:ddb)


### PR DESCRIPTION
Threaded ECL didn't work with table functions since their callbacks can be called from threads managed by DuckDB (ECL would have needed to have `ecl_import_current_thread` called on them for this to work). This PR allows for using a thread pool managed via [bordeaux-threads](https://github.com/sionescu/bordeaux-threads) instead and for turning off the usage of DuckDB internal threads via configuration.

Tests for table functions & replacement scans are now enabled again for ECL as well.