### PR TITLE
handle interactive interrupt

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,6 +6,7 @@
            #:get-ffi-type
            #:duckdb-result
            #:p-duckdb-result
+           #:duckdb-pending-result
            #:p-duckdb-column
            #:duckdb-database
            #:duckdb-connection
@@ -20,6 +21,7 @@
            #:duckdb-close
            #:duckdb-connect
            #:duckdb-disconnect
+           #:duckdb-interrupt
            #:duckdb-query
            #:duckdb-destroy-result
            #:duckdb-column-count
@@ -44,6 +46,12 @@
            #:duckdb-prepare
            #:duckdb-destroy-prepare
            #:duckdb-execute-prepared
+           #:duckdb-pending-prepared
+           #:duckdb-destroy-pending
+           #:duckdb-pending-error
+           #:duckdb-pending-execute-task
+           #:duckdb-execute-pending
+           #:duckdb-pending-execution-is-finished
            #:duckdb-nparams
            #:duckdb-param-type
            #:duckdb-clear-bindings


### PR DESCRIPTION
This works well on SBCL. I'm happy to discuss improvements and portability!

Potential issues:
1. This reraise an duckdb error after selecting the `ABORT` restart. Is this good enough?
2. This relies on interactive interrupt having an `CONTINUE` restart. Is this a reasonably portable assumption?