### PR TITLE
Optimizing translate large result set

### DIFF
--- a/duckdb-api.lisp
+++ b/duckdb-api.lisp
@@ -347,6 +347,10 @@
   (result p-duckdb-result)
   (col idx))
 
+(defcfun duckdb-column-logical-type (duckdb-logical-type)
+  (result p-duckdb-result)
+  (col idx))
+
 (defcfun duckdb-column-data (:pointer :void)
   (result p-duckdb-result)
   (col idx))
@@ -476,6 +480,10 @@
 
 (defun get-vector-type (vector)
   (with-logical-type (logical-type (duckdb-vector-get-column-type vector))
+    (resolve-logical-type logical-type)))
+
+(defun get-result-type (result column-index)
+  (with-logical-type (logical-type (duckdb-column-logical-type result column-index))
     (resolve-logical-type logical-type)))
 
 (defcfun duckdb-vector-get-data (:pointer :void)

--- a/package.lisp
+++ b/package.lisp
@@ -69,6 +69,7 @@
            #:with-data-chunk
            #:duckdb-validity-row-is-valid
            #:get-vector-type
+           #:get-result-type
            #:duckdb-appender-create
            #:duckdb-appender-error
            #:duckdb-appender-flush


### PR DESCRIPTION
Hi! This is a draft of my take at #67. It takes 1.56s for the `(progn (setq *test* (time (ddb:q "FROM read_csv('~/Downloads/8ysW.csv')"))) nil)` benchmark on SBCL! With the memcpy methods disabled, it runs in 5s.

This is currently just a proof of concept, and I'd like to discuss the interface:
1. Should there be a runtime option to enable/disable specialized array? Or a static option in `*features*` instead? It pass all test cases in its current form (i.e. enable specialized array by default) anyways, so I guess not much code really rely on unspecialized array? 
2. For `*sql-null-return-value*`, should there be some option to prevent falling back to unspecialized array? (e.g. fill in -1 for uint, and fill in NaN for floats)?

Besides, I don't use other CL implementation but I expect the unboxed translators to work on most CL implementation. Feel free to test it and add to the `#+sbcl` block!