### PR TITLE
refactor translate-value-case and translate-composite

### DIFF
--- a/duckdb-api.lisp
+++ b/duckdb-api.lisp
@@ -286,10 +286,6 @@
        (:duckdb-timestamp-ns '(:struct duckdb-timestamp))
        (:duckdb-interval '(:struct duckdb-interval))
        (:duckdb-uuid '(:struct duckdb-uuid))
-       (:duckdb-list '(:struct duckdb-list))
-       (:duckdb-struct :void)
-       (:duckdb-map '(:struct duckdb-list))
-       (:duckdb-union :void)
        (:duckdb-bit '(:struct duckdb-blob))
        (:duckdb-timestamp-tz '(:struct duckdb-timestamp))))))
 
@@ -447,7 +443,9 @@
          (setf (mem-ref p-type 'duckdb-logical-type) ,logical-type-var)
          (duckdb-destroy-logical-type p-type)))))
 
-(defstruct duckdb-logical-decimal (internal) (scale))
+(defstruct duckdb-logical-decimal
+  (internal)
+  (scale (alexandria:required-argument :scale) :type (unsigned-byte 8)))
 
 (defstruct duckdb-logical-enum (internal) (alist))
 
@@ -756,6 +754,9 @@
   (type duckdb-logical-type))
 
 (defcfun duckdb-list-vector-get-child duckdb-vector
+  (vector duckdb-vector))
+
+(defcfun duckdb-list-vector-get-size idx
   (vector duckdb-vector))
 
 (defcfun duckdb-map-type-key-type duckdb-logical-type

--- a/package.lisp
+++ b/package.lisp
@@ -34,6 +34,7 @@
            #:duckdb-vector-get-data
            #:duckdb-vector-get-validity
            #:duckdb-list-vector-get-child
+           #:duckdb-list-vector-get-size
            #:duckdb-struct-vector-get-child
            #:duckdb-data-chunk-get-column-count
            #:duckdb-data-chunk-get-size


### PR DESCRIPTION
This mostly finishes my plan to improve `translate-result`: `translate-value-case` and `translate-composite` has been rewritten as methods of `translate-vector`, and the "slow path" method that does type dispatch inside the loop over vector data is eliminated ;)

There are still areas for improvement, e.g. various `translate-from-foreign` calls, but so far it's good enough for my work and I can eschew hacks in my `local-project`! Moreover, because `translate-vector` is now extensible, I can plug in whatever domain specific hack as methods (e.g. I have an unboxed representation of timestamp that works with Petalisp).