### PR TITLE
Translate from timestamp-* correctly

### DIFF
--- a/duckdb-api.lisp
+++ b/duckdb-api.lisp
@@ -189,6 +189,29 @@
                                   (local-time:sec-of value)))
                     (round (local-time:nsec-of value) 1000)))))
 
+(defcstruct (duckdb-timestamp-s :class duckdb-timestamp-s-type)
+  (secs :int64))
+
+(defmethod translate-from-foreign (value (type duckdb-timestamp-s-type))
+  (with-foreign-slots ((secs) value (:struct duckdb-timestamp-s))
+    (local-time:unix-to-timestamp secs)))
+
+(defcstruct (duckdb-timestamp-ms :class duckdb-timestamp-ms-type)
+  (milis :int64))
+
+(defmethod translate-from-foreign (value (type duckdb-timestamp-ms-type))
+  (with-foreign-slots ((milis) value (:struct duckdb-timestamp-ms))
+    (multiple-value-bind (secs remainder) (floor milis 1000)
+      (local-time:unix-to-timestamp secs :nsec (* remainder 1000000)))))
+
+(defcstruct (duckdb-timestamp-ns :class duckdb-timestamp-ns-type)
+  (nanos :int64))
+
+(defmethod translate-from-foreign (value (type duckdb-timestamp-ns-type))
+  (with-foreign-slots ((nanos) value (:struct duckdb-timestamp-ns))
+    (multiple-value-bind (secs remainder) (floor nanos 1000000000)
+      (local-time:unix-to-timestamp secs :nsec remainder))))
+
 (defcstruct (duckdb-interval :class duckdb-interval-type)
   (months :int32)
   (days :int32)
@@ -287,9 +310,9 @@
        (:duckdb-date '(:struct duckdb-date))
        (:duckdb-time '(:struct duckdb-time))
        (:duckdb-timestamp '(:struct duckdb-timestamp))
-       (:duckdb-timestamp-s '(:struct duckdb-timestamp))
-       (:duckdb-timestamp-ms '(:struct duckdb-timestamp))
-       (:duckdb-timestamp-ns '(:struct duckdb-timestamp))
+       (:duckdb-timestamp-s '(:struct duckdb-timestamp-s))
+       (:duckdb-timestamp-ms '(:struct duckdb-timestamp-ms))
+       (:duckdb-timestamp-ns '(:struct duckdb-timestamp-ns))
        (:duckdb-interval '(:struct duckdb-interval))
        (:duckdb-uuid '(:struct duckdb-uuid))
        (:duckdb-bit '(:struct duckdb-blob))

--- a/duckdb-test.lisp
+++ b/duckdb-test.lisp
@@ -147,6 +147,54 @@
          (local-time:unix-to-timestamp 8639999999)
          b))))
 
+(test query-timestamp-s
+  (test-query (ddb:concat "SELECT '1970-01-01 23:59:59'::timestamp_s AS a"
+                          ", '2243-10-16 23:59:59'::timestamp_s AS b")
+      nil
+      (a b)
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 86399)
+         a))
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 8639999999)
+         b))))
+
+(test query-timestamp-ms
+  (test-query (ddb:concat "SELECT '1970-01-01 23:59:59'::timestamp_ms AS a"
+                          ", '2243-10-16 23:59:59'::timestamp_ms AS b")
+      nil
+      (a b)
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 86399)
+         a))
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 8639999999)
+         b))))
+
+(test query-timestamp-ns
+  (test-query (ddb:concat "SELECT '1970-01-01 23:59:59'::timestamp_ns AS a"
+                          ", '2243-10-16 23:59:59'::timestamp_ns AS b")
+      nil
+      (a b)
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 86399)
+         a))
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 8639999999)
+         b))))
+
+(test query-timestamp-tz
+  (test-query (ddb:concat "SELECT '1970-01-01 23:59:59Z'::timestamptz AS a"
+                          ", '2243-10-16 23:59:59Z'::timestamptz AS b")
+      nil
+      (a b)
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 86399)
+         a))
+    (is (local-time:timestamp=
+         (local-time:unix-to-timestamp 8639999999)
+         b))))
+
 (test query-interval
   (test-query (ddb:concat "SELECT INTERVAL 1001 YEAR "
                           "+ INTERVAL 1001 MONTH "


### PR DESCRIPTION
DuckDB documentation quite misleadingly states `timestamp*` type are all stored in `struct duckdb_timestamp`, but in fact they're stored in different units! Therefore the previous translation from `timestamp_s, timestamp_ms, timestamp_ns` are incorrect. This patch fixes that.

There's some code duplication introduced, and generally the `translate-from-foreign` mechanism is less efficient than desired (a CLOS generic function call for every element!). I would like to address these, but maybe in a later patch. Currently I just made it work™.